### PR TITLE
add receipt parameter to put() and send () function 

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,1 +1,3 @@
 * Be more awesome
+
+* Support auto reconnect 

--- a/stompy/distmeta.py
+++ b/stompy/distmeta.py
@@ -1,6 +1,6 @@
 """Implementation of the STOMP protocol in Python.
 """
-VERSION = (0, 2, 9)
+VERSION = (0, 2, 10)
 __version__ = ".".join(map(str, VERSION))
 __author__ = "Benjamin W. Smith"
 __contact__ = "benjaminwarfield@just-another.net"

--- a/stompy/simple.py
+++ b/stompy/simple.py
@@ -63,7 +63,7 @@ class Client(object):
         """
         return self.get(block=False)
 
-    def put(self, item, destination, persistent=True, conf=None):
+    def put(self, item, destination, persistent=True, conf=None,receipt=True):
         """Put an item into the queue.
 
         :param item: Body of the message.
@@ -78,7 +78,7 @@ class Client(object):
         conf = self._make_conf(conf, body=item, destination=destination,
                                persistent=persistent)
 
-        return self.stomp.send(conf)
+        return self.stomp.send(conf,receipt)
 
     def connect(self, username=None, password=None, clientid=None):
         """Connect to the broker.

--- a/stompy/stomp.py
+++ b/stompy/stomp.py
@@ -68,7 +68,7 @@ class Stomp(object):
             pass
         self.connected = False
 
-    def send(self, conf=None):
+    def send(self, conf=None, receipt=True):
         """Send message to STOMP server
 
         You'll need to pass the body and any other headers your
@@ -84,18 +84,10 @@ class Stomp(object):
             ...                 'persistent': 'true'})
 
         """
-        self._send(conf,True)
-
-    def send_noreceipt(self,conf=None):
-        """Send message to STOMP server without receipt
-        """
-        self._send(conf,False)
-        
-    def _send(self,conf=None,receipt)
         headers = dict(conf)
         body = headers.pop("body", "")
         return self._send_command("SEND", headers, extra={"body": body},
-                                  want_receipt=reveipt)
+                                  want_receipt=receipt)
 
     def _build_frame(self, *args, **kwargs):
         self._connected_or_raise()

--- a/stompy/stomp.py
+++ b/stompy/stomp.py
@@ -84,10 +84,18 @@ class Stomp(object):
             ...                 'persistent': 'true'})
 
         """
+        self._send(conf,True)
+
+    def send_noreceipt(self,conf=None):
+        """Send message to STOMP server without receipt
+        """
+        self._send(conf,False)
+        
+    def _send(self,conf=None,receipt)
         headers = dict(conf)
         body = headers.pop("body", "")
         return self._send_command("SEND", headers, extra={"body": body},
-                                  want_receipt=True)
+                                  want_receipt=reveipt)
 
     def _build_frame(self, *args, **kwargs):
         self._connected_or_raise()


### PR DESCRIPTION
We can set receipt=False if we do not need receipt when send message to STOMP server, either in simple way using put(...) or in stomp way using send(...) .